### PR TITLE
B2c validate

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -209,6 +209,17 @@ $result = json_decode($response);
 return $result;
 ```
 
+In some cases, You might want to verify the recipient of the payment, using their ID number. To do this, you need to call the `validated_b2c` method, and pass the recipients ID Number as the 5th parameter.
+If the ID provided does not match the phone number on Safaricom Database, the transaction will fail.
+
+```php
+use Iankumu\Mpesa\Facades\Mpesa;
+$response=Mpesa::validated_b2c('0708374149','SalaryPayment',1000,'salary payment','12345678');
+
+$result = json_decode($response);
+return $result;
+```
+
 Upon success you should receive a response similar to the one below
 
 ```json

--- a/tests/Unit/ValidatedB2CTest.php
+++ b/tests/Unit/ValidatedB2CTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Iankumu\Mpesa\Tests\Unit;
+
+use Iankumu\Mpesa\Mpesa;
+use Iankumu\Mpesa\Tests\TestCase;
+use Illuminate\Support\Facades\Log;
+
+class ValidatedB2CTest extends TestCase
+{
+    //test can perform validated b2c
+    /**@test */
+    public function can_validate_b2c()
+    {
+        $mpesa = $this->createStub(Mpesa::class);
+
+        $mpesa->method('validated_b2c')
+            ->with('0707070707', 'SalaryPayment', 100, 'Salary Payment','120912992')//Will take a phone number and ID Number of the person to be paid
+            ->willReturn(true);
+
+        $result = $mpesa->validated_b2c('0707070707', 'SalaryPayment', 100, 'Salary Payment','120912992');
+        $result->assertJsonStructure([
+            'ConversationID',
+            'OriginatorConversationID',
+            'ResponseCode',
+            'ResponseDescription',
+        ]);
+    }
+}


### PR DESCRIPTION
Added B2C Validate Option, where you can pass Recipient ID Number for Validation. Transaction Fails if ID Provided does not match the ID  registered with the phone number