### PR TITLE
Fix: Definition of B2C consumer key and secret in configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,17 +47,30 @@ return [
     'environment' => env('MPESA_ENVIRONMENT', 'sandbox'),
 
     /*-----------------------------------------
-        |The Mpesa Consumer Key
+        |The Mpesa C2B Consumer Key
         |------------------------------------------
         */
     'mpesa_consumer_key' => env('MPESA_CONSUMER_KEY'),
 
     /*-----------------------------------------
-        |The Mpesa Consumer Secret
+        |The Mpesa C2B Consumer Secret
         |------------------------------------------
         */
     'mpesa_consumer_secret' => env('MPESA_CONSUMER_SECRET'),
 
+    
+    /*-----------------------------------------
+        |The Mpesa B2C Consumer Key
+        |------------------------------------------
+        */
+    'b2c_consumer_key' => env('B2C_CONSUMER_KEY'),
+
+    /*-----------------------------------------
+        |The Mpesa B2C Consumer Secret
+        |------------------------------------------
+        */
+    'b2c_consumer_secret' => env('B2C_CONSUMER_SECRET'),
+    
     /*-----------------------------------------
         |The Lipa na Mpesa Online Passkey
         |------------------------------------------

--- a/config/mpesa.php
+++ b/config/mpesa.php
@@ -5,16 +5,29 @@ return [
     'environment' => env('MPESA_ENVIRONMENT', 'sandbox'),
 
     /*-----------------------------------------
-        |The Mpesa Consumer Key
+        |The Mpesa C2B Consumer Key
         |------------------------------------------
         */
     'mpesa_consumer_key' => env('MPESA_CONSUMER_KEY'),
 
     /*-----------------------------------------
-        |The Mpesa Consumer Secret
+        |The Mpesa C2B Consumer Secret
         |------------------------------------------
         */
     'mpesa_consumer_secret' => env('MPESA_CONSUMER_SECRET'),
+
+
+    /*-----------------------------------------
+        |The Mpesa B2C Consumer Key
+        |------------------------------------------
+        */
+    'b2c_consumer_key' => env('B2C_CONSUMER_KEY'),
+
+    /*-----------------------------------------
+        |The Mpesa B2C Consumer Secret
+        |------------------------------------------
+        */
+    'b2c_consumer_secret' => env('B2C_CONSUMER_SECRET'),
 
     /*-----------------------------------------
         |The Lipa na Mpesa Online Passkey

--- a/src/Mpesa.php
+++ b/src/Mpesa.php
@@ -80,9 +80,10 @@ class Mpesa
      * @param string $account_number The account number for a paybill or a reference number for a till number. Maximum of 12 Characters.
      * @param string|null $callbackurl The callback url for Mpesa Express
      * @param string $transactionType The type of transaction. Can be CustomerPayBillOnline or CustomerBuyGoodsOnline
+     * @param string $shortCodeType The type of shortcode to use. Can be C2B for incoming payments or B2C and B2B for outgoing payments.
      * @return \Illuminate\Http\Client\Response
      */
-    public function stkpush($phonenumber, $amount, $account_number, $callbackurl = null, $transactionType = self::PAYBILL)
+    public function stkpush($phonenumber, $amount, $account_number, $callbackurl = null, $transactionType = self::PAYBILL, $shortCodeType = 'C2B')
     {
 
         $validTypes = [self::PAYBILL, self::TILL];
@@ -116,7 +117,7 @@ class Mpesa
             'CallBackURL' => $this->resolveCallbackUrl($callbackurl, 'callback_url', 'callback_url'),
         ];
 
-        return $this->MpesaRequest($url, $data);
+        return $this->MpesaRequest($url, $data, $shortCodeType);
     }
 
     /**
@@ -125,9 +126,10 @@ class Mpesa
      * This method is used to check the status of a Lipa Na M-Pesa Online Payment.
      *
      * @param string $checkoutRequestId This is a global unique identifier of the processed checkout transaction request.
+     * @param string $shortCodeType The type of shortcode to use. Can be C2B for incoming payments or B2C and B2B for outgoing payments.
      * @return \Illuminate\Http\Client\Response
      */
-    public function stkquery($checkoutRequestId)
+    public function stkquery($checkoutRequestId, $shortCodeType = 'C2B')
     {
         $post_data = [
             'BusinessShortCode' => $this->shortcode,
@@ -138,7 +140,7 @@ class Mpesa
 
         $url = $this->url . '/mpesa/stkpushquery/v1/query';
 
-        return $this->MpesaRequest($url, $post_data);
+        return $this->MpesaRequest($url, $post_data, $shortCodeType);
     }
 
     /**
@@ -152,9 +154,10 @@ class Mpesa
      * @param string $remarks Any additional information. Must be present.
      * @param string|null $result_url The Result Url where payload will be sent.
      * @param string|null $timeout_url The Timeout Url where payload will be sent. Must be present.
+     * @param string $shortCodeType The type of shortcode to use. Can be C2B for incoming payments or B2C and B2B for outgoing payments.
      * @return \Illuminate\Http\Client\Response
      */
-    public function b2c($phonenumber, $command_id, $amount, $remarks, $result_url = null, $timeout_url = null)
+    public function b2c($phonenumber, $command_id, $amount, $remarks, $result_url = null, $timeout_url = null, $shortCodeType = 'B2C')
     {
         $url = $this->url . '/mpesa/b2c/v1/paymentrequest';
 
@@ -171,7 +174,7 @@ class Mpesa
             'QueueTimeOutURL' => $this->resolveCallbackUrl($timeout_url, 'b2c_timeout_url', 'b2c_timeout_url'),
         ];
 
-        return $this->MpesaRequest($url, $body);
+        return $this->MpesaRequest($url, $body, $shortCodeType);
     }
 
     /**
@@ -187,9 +190,10 @@ class Mpesa
      * @param string $id_number The id number of the recipient
      * @param string|null $result_url The Result Url where payload will be sent.
      * @param string|null $timeout_url The Timeout Url where payload will be sent. Must be present.
+     * @param string $shortCodeType The type of shortcode to use. Can be C2B for incoming payments or B2C and B2B for outgoing payments.
      * @return \Illuminate\Http\Client\Response
      */
-    public function validated_b2c($phonenumber, $command_id, $amount, $remarks, $id_number, $result_url = null, $timeout_url = null)
+    public function validated_b2c($phonenumber, $command_id, $amount, $remarks, $id_number, $result_url = null, $timeout_url = null, $shortCodeType = 'B2C')
     {
         $url = $this->url . '/mpesa/b2cvalidate/v2/paymentrequest';
         $body = [
@@ -208,7 +212,7 @@ class Mpesa
             'QueueTimeOutURL' => $this->resolveCallbackUrl($timeout_url, 'b2c_timeout_url', 'b2c_timeout_url'),
         ];
 
-        return $this->MpesaRequest($url, $body);
+        return $this->MpesaRequest($url, $body, $shortCodeType);
     }
 
     /**
@@ -221,9 +225,10 @@ class Mpesa
      * @param string $command_id The type of transaction being made. Can be BusinessPayBill, MerchantToMerchantTransfer, MerchantTransferFromMerchantToWorking, MerchantServicesMMFAccountTransfer, AgencyFloatAdvance
      * @param string $remarks Any additional information. Must be present.
      * @param string $account_number Required for “BusinessPaybill” CommandID.
-     * * @return \Illuminate\Http\Client\Response
+     * @param string $shortCodeType The type of shortcode to use. Can be C2B for incoming payments or B2C and B2B for outgoing payments.
+     * @return \Illuminate\Http\Client\Response
      */
-    public function b2b($receiver_shortcode, $command_id, $amount, $remarks, $account_number = null, $b2b_result_url = null, $b2b_timeout_url = null)
+    public function b2b($receiver_shortcode, $command_id, $amount, $remarks, $account_number = null, $b2b_result_url = null, $b2b_timeout_url = null, $shortCodeType = 'B2B')
     {
         $url = $this->url . "/mpesa/b2b/v1/paymentrequest";
 
@@ -248,7 +253,7 @@ class Mpesa
             $body['AccountReference'] = $account_number;
         }
 
-        return $this->MpesaRequest($url, $body);
+        return $this->MpesaRequest($url, $body, $shortCodeType);
     }
 
     /**
@@ -259,9 +264,10 @@ class Mpesa
      * @param string $shortcode The till number or paybill number the urls will be associated with
      * @param string|null $confirmurl The URL that receives the confirmation of the transaction
      * @param string|null $validateurl The URL that receives the validation of the transaction
+     * @param string $shortCodeType The type of shortcode to use. Can be C2B for incoming payments or B2C and B2B for outgoing payments.
      * @return \Illuminate\Http\Client\Response
      */
-    public function c2bregisterURLS($shortcode, $confirmurl = null, $validateurl = null)
+    public function c2bregisterURLS($shortcode, $confirmurl = null, $validateurl = null, $shortCodeType = 'C2B')
     {
         $url = $this->url . '/mpesa/c2b/v2/registerurl';
 
@@ -272,7 +278,7 @@ class Mpesa
             'ValidationURL' => $this->resolveCallbackUrl($validateurl, 'c2b_validation_url', 'c2b_validation_url'),
         ];
 
-        return $this->MpesaRequest($url, $body);
+        return $this->MpesaRequest($url, $body, $shortCodeType);
     }
 
     /**
@@ -285,9 +291,10 @@ class Mpesa
      * @param string $shortcode The Paybill/Till number receiving the funds
      * @param string $command_id The Type of transaction. Whether it is a paybill transaction(CustomerPayBillOnline) or a Till number transaction(CustomerBuyGoodsOnline)
      * @param string $account_number The account number for a paybill. The default is null
+     * @param string $shortCodeType The type of shortcode to use. Can be C2B for incoming payments or B2C and B2B for outgoing payments.
      * @return \Illuminate\Http\Client\Response
      */
-    public function c2bsimulate($phonenumber, $amount, $shortcode, $command_id, $account_number = null)
+    public function c2bsimulate($phonenumber, $amount, $shortcode, $command_id, $account_number = null, $shortCodeType = 'C2B')
     {
         if ($command_id == self::PAYBILL) {
             //Paybill Request Body
@@ -310,7 +317,7 @@ class Mpesa
 
         $url = $this->url . '/mpesa/c2b/v2/simulate';
 
-        return $this->MpesaRequest($url, $data);
+        return $this->MpesaRequest($url, $data, $shortCodeType);
     }
 
     /**
@@ -324,9 +331,10 @@ class Mpesa
      * @param string $remarks Any additional information. Must be present.
      * @param string|null $result_url The Result Url where payload will be sent.
      * @param string|null $timeout_url The Timeout Url where payload will be sent.
+     * @param string $shortCodeType The type of shortcode to use. Can be C2B for incoming payments or B2C and B2B for outgoing payments.
      * @return \Illuminate\Http\Client\Response
      */
-    public function transactionStatus($shortcode, $transactionid, $identiertype, $remarks, $result_url = null, $timeout_url = null)
+    public function transactionStatus($shortcode, $transactionid, $identiertype, $remarks, $result_url = null, $timeout_url = null, $shortCodeType = 'C2B')
     {
         $url = $this->url . '/mpesa/transactionstatus/v1/query';
 
@@ -343,7 +351,7 @@ class Mpesa
             'QueueTimeOutURL' => $this->resolveCallbackUrl($timeout_url, 'status_timeout_url', 'status_timeout_url'),
         ];
 
-        return $this->MpesaRequest($url, $body);
+        return $this->MpesaRequest($url, $body, $shortCodeType);
     }
 
     /**
@@ -356,9 +364,10 @@ class Mpesa
      * @param string $remarks Any additional information. Must be present.
      * @param string|null $result_url The Result Url where payload will be sent.
      * @param string|null $timeout_url The Timeout Url where payload will be sent.
+     * @param string $shortCodeType The type of shortcode to use. Can be C2B for incoming payments or B2C and B2B for outgoing payments.
      * @return \Illuminate\Http\Client\Response
      */
-    public function accountBalance($shortcode, $identiertype, $remarks, $result_url = null, $timeout_url = null)
+    public function accountBalance($shortcode, $identiertype, $remarks, $result_url = null, $timeout_url = null, $shortCodeType = 'C2B')
     {
         $url = $this->url . '/mpesa/accountbalance/v1/query';
 
@@ -373,7 +382,7 @@ class Mpesa
             'QueueTimeOutURL' => $this->resolveCallbackUrl($timeout_url, 'balance_timeout_url', 'balance_timeout_url'),
         ];
 
-        return $this->MpesaRequest($url, $body);
+        return $this->MpesaRequest($url, $body, $shortCodeType);
     }
 
     /**
@@ -385,9 +394,10 @@ class Mpesa
      * @param int $shortcode Your Org's shortcode.
      * @param string $transactionid This is the M-Pesa Transaction ID of the transaction which you wish to reverse.
      * @param string $remarks Any additional information. Must be present.
+     * @param string $shortCodeType The type of shortcode to use. Can be C2B for incoming payments or B2C and B2B for outgoing payments.
      * @return \Illuminate\Http\Client\Response
      */
-    public function reversal($shortcode, $transactionid, $amount, $remarks, $reverseresulturl = null, $reversetimeouturl = null)
+    public function reversal($shortcode, $transactionid, $amount, $remarks, $reverseresulturl = null, $reversetimeouturl = null, $shortCodeType = 'C2B')
     {
         $url = $this->url . '/mpesa/reversal/v1/request';
 
@@ -405,6 +415,6 @@ class Mpesa
             'QueueTimeOutURL' => $this->resolveCallbackUrl($reversetimeouturl, 'reversal_timeout_url', 'reversal_timeout_url'),
         ];
 
-        return $this->MpesaRequest($url, $body);
+        return $this->MpesaRequest($url, $body, $shortCodeType);
     }
 }

--- a/src/Utils/MpesaHelper.php
+++ b/src/Utils/MpesaHelper.php
@@ -25,10 +25,17 @@ trait MpesaHelper
     }
 
     // Generate an AccessToken using the Consumer Key and Consumer Secret
-    public function generateAccessToken()
+    public function generateAccessToken($shortCodeType)
     {
-        $consumer_key = $this->getConfig('mpesa_consumer_key');
-        $consumer_secret = $this->getConfig('mpesa_consumer_secret');
+        if ($shortCodeType == "B2C" || $shortCodeType == "B2B") {
+            //use to B2C consumer key and secret
+            $consumer_key = $this->getConfig('b2c_consumer_key');
+            $consumer_secret = $this->getConfig('b2c_consumer_secret');
+        } else {
+            //default to C2B consumer key and secret
+            $consumer_key = $this->getConfig('mpesa_consumer_key');
+            $consumer_secret = $this->getConfig('mpesa_consumer_secret');
+        }
 
         $url = $this->url . '/oauth/v1/generate?grant_type=client_credentials';
 
@@ -41,10 +48,10 @@ trait MpesaHelper
     }
 
     // Common Format Of The Mpesa APIs.
-    public function MpesaRequest($url, $body)
+    public function MpesaRequest($url, $body, $shortCodeType = 'C2B')
     {
 
-        $response = Http::withToken($this->generateAccessToken())
+        $response = Http::withToken($this->generateAccessToken($shortCodeType))
             ->acceptJson()
             ->post($url, $body);
 


### PR DESCRIPTION
Fix: 
Added definition of B2C consumer key and secret in the configs for a B2C shortcode. These credentials will be different from the C2B ones because they are different shortcodes hence you have to create two different apps on daraja. Current configs only allow definition of one set of consumer key/secret, which may not be appropriate for use cases with two shortcodes (B2C and C2B)

This change will not affect current users as it defaults to the C2B consumer key/secret as currently implemented.